### PR TITLE
Fix link when root is not '/'

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -30,6 +30,16 @@
   <% if (theme.favicon) { %>
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
+  
+  <script type="text/javascript">
+    //Export hexo config to js
+    var HexoConfig = {
+      root: '<%= config.root %>',
+      search: {
+        enabled: '<%= theme.search.enable %>'
+      }
+    };
+  </script>
 
 	<script src="https://use.typekit.net/eyf3hir.js"></script>
   <script>try{Typekit.load({ async: false });}catch(e){}</script>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,7 +1,7 @@
 <header id="header">
 	<div id="header-wrapper" class="clearfix">
 		<a id="logo" href="<%= url_for('/') %>">
-			<img src="/images/logo.png" />
+			<img src="<%= url_for('/images/logo.png') %>" />
 			<span id="site-desc">
 			  <%- theme.site_desc %>
       </span>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,6 +1,6 @@
 <header id="header">
 	<div id="header-wrapper" class="clearfix">
-		<a id="logo" href="/">
+		<a id="logo" href="<%= url_for('/') %>">
 			<img src="/images/logo.png" />
 			<span id="site-desc">
 			  <%- theme.site_desc %>
@@ -14,7 +14,7 @@
   	<nav>
   		<% theme.navigation.forEach(function(value, key) {
             if (value.url && value.slug && value.name) { %>
-        <a href="<%= value.url %>" class="nav-<%= value.slug %> nav">
+        <a href="<%= url_for(value.url) %>" class="nav-<%= value.slug %> nav">
           <%= value.name %>
         </a>
       <% } }); %>

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -200,7 +200,7 @@ var SearchService = "";
       var html = "";
       if (self.config.brands[service] && self.config.brands[service].logo) {
         html += "<a href='" +self.config.brands[service].url+ "' class='" +service+ "'>";
-        html +=    '<img src="' +HexoConfig.root.substr(0,HexoConfig.root.length-1)+self.config.imagePath+self.config.brands[service].logo+ '" />';
+        html +=    '<img src="' +(HexoConfig.root+self.config.imagePath).replace(/\/{2,}/g, '/')+self.config.brands[service].logo+ '" />';
         html += "</a>";
         self.dom.modal_logo.html(html);
       }
@@ -653,7 +653,7 @@ var HexoSearch;
   HexoSearch = function(options) {
     SearchService.apply(this, arguments);
     var self = this;
-    self.config.endpoint = (HexoConfig.root + ((options||{}).endpoint || "/content.json")).replace('//', '/');
+    self.config.endpoint = (HexoConfig.root + ((options||{}).endpoint || "/content.json")).replace(/\/{2,}/g, '/');
     self.cache = "";
     
     /**

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -7,6 +7,11 @@ var SearchService = "";
    */
   SearchService = function(options) {
     var self = this;
+
+    // if search.enable is false, not init.
+    if (!HexoConfig.search.enabled || HexoConfig.search.enabled === "false") {
+      return;
+    }
     
     self.config = $.extend({
       per_page: 10,
@@ -195,7 +200,7 @@ var SearchService = "";
       var html = "";
       if (self.config.brands[service] && self.config.brands[service].logo) {
         html += "<a href='" +self.config.brands[service].url+ "' class='" +service+ "'>";
-        html +=    '<img src="' +self.config.imagePath+self.config.brands[service].logo+ '" />';
+        html +=    '<img src="' +HexoConfig.root.substr(0,HexoConfig.root.length-1)+self.config.imagePath+self.config.brands[service].logo+ '" />';
         html += "</a>";
         self.dom.modal_logo.html(html);
       }

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -653,7 +653,7 @@ var HexoSearch;
   HexoSearch = function(options) {
     SearchService.apply(this, arguments);
     var self = this;
-    self.config.endpoint = (options||{}).endpoint || "/content.json";
+    self.config.endpoint = (HexoConfig.root + ((options||{}).endpoint || "/content.json")).replace('//', '/');
     self.cache = "";
     
     /**

--- a/source/less/_fonts.less
+++ b/source/less/_fonts.less
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'icomoon';
-  src:  url('../fonts/icomoon.eot?7jyvbf');
-  src:  url('../fonts/icomoon.eot?7jyvbf#iefix') format('embedded-opentype'),
-    url('../fonts/icomoon.ttf?7jyvbf') format('truetype'),
-    url('../fonts/icomoon.woff?7jyvbf') format('woff'),
-    url('../fonts/icomoon.svg?7jyvbf#icomoon') format('svg');
+  src:  url('fonts/icomoon.eot?7jyvbf');
+  src:  url('fonts/icomoon.eot?7jyvbf#iefix') format('embedded-opentype'),
+    url('fonts/icomoon.ttf?7jyvbf') format('truetype'),
+    url('fonts/icomoon.woff?7jyvbf') format('woff'),
+    url('fonts/icomoon.svg?7jyvbf#icomoon') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
网站的路径并不一定在根路径下，例如`http://site.com/blog`，root为`/blog/`，但主题中部分连接地址未加上root路径，导致部分连接不准确和部分样式丢失，例如点击`About`会跳转到`http://site.com/about`而不是`http://site.com/blog/about`

~~其中字体的修改去掉了`../`前缀后，测试是OK的，但不清楚会不会对其它方面造成影响（我对CSS不太熟）~~
样式文件生成在根目录，与font字体的相对路径不需要`../`
![image](https://user-images.githubusercontent.com/15902347/50210113-4b105600-03b0-11e9-8896-fe75c16ff3f0.png)
