### PR TITLE
Remove meta description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 # Meta
-description: A minimal hexo theme.
 keywords: hexo,theme,otakism,otaku
 site_desc: otaku keeps alive
 

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -17,7 +17,6 @@
     }
     %>
     <title><% if (title) { %><%= title %> | <% } %><%= config.title %></title>
-    <meta name="description" content="<%- theme.description %>"/>
     <meta name="keywords" content="<%- theme.keywords %>"/>
     <meta name="HandheldFriendly" content="True"/>
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
No need to add meta description in the theme's `_config.yml`:

Hexo itself will inject a meta description: https://github.com/hexojs/hexo/blob/557487a2f8ab0065bf94d5a9466c54034f1db17f/lib/plugins/helper/open_graph.js#L62

The meta description generated by Hexo will be the excerpt of the post if the current page is a post. And Disqus usually scrapes 
meta description as the description of a thread.
https://help.disqus.com/en/articles/3754345-thread-descriptions

The current configuration of hexo-theme-memory makes Disqus use my website description instead of the post excerpt generated by hexo as the description of the thread. And it generates two meta descriptions on one page sometimes.

Plus, `description` can be configurated in the site's `_config.yml` instead, which will be available by `config.description`.

https://hexo.io/docs/configuration#Extensions
https://hexo.io/docs/variables