### PR TITLE
Use new GA script

### DIFF
--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -1,12 +1,12 @@
 <% if (theme.google_analytics){ %>
-    <!-- Google Analytics -->
-    <script type="text/javascript">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', '<%= theme.google_analytics %>', 'auto');
-      ga('send', 'pageview');
-    </script>
-    <!-- End Google Analytics -->
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics %>"></script>
+  <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '<%= theme.google_analytics %>');
+  </script>
 <% } %>
+

--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -2,11 +2,11 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics %>"></script>
     <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    gtag('config', '<%= theme.google_analytics %>');
+        gtag('config', '<%= theme.google_analytics %>');
     </script>
 <% } %>
 

--- a/layout/_partial/google-analytics.ejs
+++ b/layout/_partial/google-analytics.ejs
@@ -1,12 +1,12 @@
 <% if (theme.google_analytics){ %>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics %>"></script>
-  <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= theme.google_analytics %>"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('config', '<%= theme.google_analytics %>');
-  </script>
+    gtag('config', '<%= theme.google_analytics %>');
+    </script>
 <% } %>
 


### PR DESCRIPTION
When I created a new site today, I was surprised to know that Google is recommending a new script and plans to [deprecate UA tracking ids](https://support.google.com/analytics/answer/9539598?hl=en). This new script should support both UA tracking ids and the new G4 id. 

I found some other popular hexo themes[[1](https://github.com/volantis-x/hexo-theme-volantis/blob/56b79197b42f3fed3ebde221b9ff9b987a1dd792/layout/_plugins/analytics/script.ejs)][[2](https://github.com/jerryc127/hexo-theme-butterfly/blob/632cb37bc5de836d4a08b67658dd186e882c5a37/layout/includes/head/analytics.pug)] are already using the new script now.