### PR TITLE
Add package.json for a faster way of installing theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,25 @@ This theme is also available on:
 
 * Ghost version: [ghost-theme-memory](https://github.com/artchen/ghost-theme-memory)
 
-## Dependencies
+## Installation
 
-Install these Hexo plugins to unlock the full potential of this theme:
+Git Clone:
+```bash
+git clone https://github.com/artchen/hexo-theme-memory.git themes/hexo-theme-memory
+```
 
-* hexo-generator-archive
-* hexo-generator-tag
-* hexo-renderer-ejs
-* hexo-renderer-scss
-* hexo-renderer-marked
-* hexo-pagination
-* hexo-toc
+Install Dependencies in Hexo site root directory:
+```bash
+npm i github:artchen/hexo-theme-memory
+```
+<details>
+  <summary>If installing dependencies fails, try</summary>
+
+  ```bash
+  npm i hexo-generator-archive hexo-generator-tag hexo-renderer-ejs hexo-renderer-dartsass hexo-renderer-marked hexo-pagination hexo-toc
+  ```
+
+</details>
 
 ## Customization
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "description": "Memory is a minimal theme for [Hexo](http://hexo.io).",
+  "dependencies": {
+    "hexo-generator-archive": "^1.0.0",
+    "hexo-generator-tag": "^1.0.0",
+    "hexo-pagination": "^2.0.0",
+    "hexo-renderer-dartsass": "^0.1.2",
+    "hexo-renderer-ejs": "^2.0.0",
+    "hexo-renderer-marked": "^5.0.0",
+    "hexo-toc": "^1.1.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "hexo-theme-memory",
   "description": "Memory is a minimal theme for [Hexo](http://hexo.io).",
   "dependencies": {
     "hexo-generator-archive": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hexo-theme-memory",
   "description": "Memory is a minimal theme for [Hexo](http://hexo.io).",
+  "version": "2.1.0",
   "dependencies": {
     "hexo-generator-archive": "^1.0.0",
     "hexo-generator-tag": "^1.0.0",


### PR DESCRIPTION
Add a package.json for a faster way of installing theme.

Replaced `hexo-renderer-scss` with `hexo-renderer-dartsass` because `hexo-renderer-scss` has not been maintained for quite a few years and installing it always throws an error on my machine: 

```
npm ERR! gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
```

And `hexo-renderer-scss` also requires me to install python2:
```
npm ERR! gyp ERR! stack Error: Command failed: /usr/local/bin/python3 -c import sys; print "%s.%s.%s" % sys.version_info[:3];
npm ERR! gyp ERR! stack   File "<string>", line 1
npm ERR! gyp ERR! stack     import sys; print "%s.%s.%s" % sys.version_info[:3];
npm ERR! gyp ERR! stack                       ^
npm ERR! gyp ERR! stack SyntaxError: invalid syntax
```